### PR TITLE
fixed fail that get caused by missing root access to cloud-localds 

### DIFF
--- a/plugins/modules/volume_cloudinit.py
+++ b/plugins/modules/volume_cloudinit.py
@@ -131,17 +131,10 @@ def cloud_localds(volume_format,
     #       Ref.: https://salsa.debian.org/cloud-team/cloud-utils/-/blob/master/bin/cloud-localds
 
     
-
-    cloud_localds_path =  module.run_command('which cloud-localds')
-    if cloud_localds_path:
-        cmd = cloud_localds_path
-    else:
-        alt_path = 'if [ -d "/usr/local/sbin/cloud-localds" ]; then  echo "true" fi'
-        if alt_path == 'true':
-            cmd = '/usr/local/sbin/cloud-localds'
-        else:
-            return module.fail_json(msg="could not find cloud-localds on your libvirt-host machine!")
-
+    cmd = "cloud-localds"
+    check_sudo_access =  module.run_command('which cloud-localds')
+    if check_sudo_access is not "/usr/local/sbin/cloud-localds":
+        cmd = '/usr/local/sbin/cloud-localds'
     if volume_format:
         cmd += ' --disk-format "%s"' % volume_format
 

--- a/plugins/modules/volume_cloudinit.py
+++ b/plugins/modules/volume_cloudinit.py
@@ -130,7 +130,18 @@ def cloud_localds(volume_format,
     #       because it is not available on Red Hat Enterprise Linux 8 / 9 and CentOS 8 / 9.
     #       Ref.: https://salsa.debian.org/cloud-team/cloud-utils/-/blob/master/bin/cloud-localds
 
-    cmd = 'cloud-localds'
+    
+
+    cloud_localds_path =  module.run_command('which cloud-localds')
+    if cloud_localds_path:
+        cmd = cloud_localds_path
+    else:
+        alt_path = 'if [ -d "/usr/local/sbin/cloud-localds" ]; then  echo "true" fi'
+        if alt_path == 'true':
+            cmd = '/usr/local/sbin/cloud-localds'
+        else:
+            return module.fail_json(msg="could not find cloud-localds on your libvirt-host machine!")
+
     if volume_format:
         cmd += ' --disk-format "%s"' % volume_format
 

--- a/roles/server/defaults/main.yml
+++ b/roles/server/defaults/main.yml
@@ -115,7 +115,9 @@ volume_capacity: |-
     {
         'CentOS 7': '5G',
         'Debian 10': '5G',
-        'Ubuntu 18.04': '5G'
+        'Ubuntu 18.04': '5G',
+        'Red Hat Enterprise Linux ': '5G'
+
     }[distribution_id | join(' ')] | default('10G')
     }}
 


### PR DESCRIPTION
##  Cloud-localds and RHEL 9
cause:
```bash
$ sudo which cloud-localds
which: no cloud-localds in (/sbin:/bin:/usr/sbin:/usr/bin)
]$ which cloud-localds
/usr/local/sbin/cloud-localds
```
 ---

### additional changes

- added a missing storage default value for rhel 

--- 
